### PR TITLE
extend: endpoint server with domain url string

### DIFF
--- a/src/wg_conf.rs
+++ b/src/wg_conf.rs
@@ -43,7 +43,7 @@ impl ToString for IpAddrExt {
     fn to_string(&self) -> String {
         match self {
             Self::Ip(ip_addr) => ip_addr.to_string(),
-            Self::Domain(domain_url) => domain_url.clone(),
+            Self::Domain(domain_name) => domain_name.clone(),
         }
     }
 }

--- a/src/wg_conf.rs
+++ b/src/wg_conf.rs
@@ -16,9 +16,37 @@ use crate::WgClientConf;
 #[cfg(feature = "wg_engine")]
 use ipnetwork::IpNetwork;
 #[cfg(feature = "wg_engine")]
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 
 const CONF_EXTENSION: &'static str = "conf";
+
+#[cfg(feature = "wg_engine")]
+pub enum IpAddrExt {
+    Ip(IpAddr),
+    Domain(String)
+}
+
+#[cfg(feature = "wg_engine")]
+impl std::str::FromStr for IpAddrExt {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Ok(ip) = input.parse::<IpAddr>() {
+            return Ok(Self::Ip(ip));
+        }
+        Ok(Self::Domain(input.to_string()))
+    }
+}
+
+#[cfg(feature = "wg_engine")]
+impl ToString for IpAddrExt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Ip(ip_addr) => ip_addr.to_string(),
+            Self::Domain(domain_url) => domain_url.clone(),
+        }
+    }
+}
 
 /// Represents WG configuration file
 #[derive(Debug)]
@@ -286,7 +314,7 @@ impl WgConf {
     pub fn generate_peer(
         &mut self,
         client_address: IpAddr,
-        server_endpoint: IpAddr,
+        server_endpoint: IpAddrExt,
         server_allowed_ips: Vec<IpNetwork>,
         dns: Option<IpAddr>,
         use_preshared_key: bool,
@@ -320,7 +348,7 @@ impl WgConf {
             WgInterface::new(client_private_key, client_address, None, dns, None, None)?;
 
         let server_listen_port = self.interface()?.listen_port.unwrap(); // for server there is always listen port
-        let server_endpoint: SocketAddr =
+        let server_endpoint: super::SocketAddrExt =
             format!("{}:{}", server_endpoint.to_string(), server_listen_port)
                 .parse()
                 .unwrap();
@@ -1502,7 +1530,7 @@ DNS = 0.0.0.0
 
     #[cfg(feature = "wg_engine")]
     #[test]
-    fn generate_peer_0_common_scenario() {
+    fn generate_peer_scenario_ip_endpoint() {
         // Arrange
         const TEST_CONF_FILE: &str = "wg20.conf";
         let content = INTERFACE_CONTENT.to_string() + "\n" + PEER_CONTENT + "\n";
@@ -1561,7 +1589,77 @@ DNS = 0.0.0.0
         );
         assert_eq!(
             "127.0.0.2:8080",
-            client_peer_w_server.endpoint.unwrap().to_string()
+            client_peer_w_server.endpoint.clone().unwrap().to_string()
+        );
+        assert_eq!(
+            last_peer.preshared_key(),
+            client_peer_w_server.preshared_key()
+        );
+        assert_eq!(10, client_peer_w_server.persistent_keepalive.unwrap());
+    }
+
+    #[cfg(feature = "wg_engine")]
+    #[test]
+    fn generate_peer_scenario_domain_endpoint() {
+        // Arrange
+        const TEST_CONF_FILE: &str = "wg21.conf";
+        let content = INTERFACE_CONTENT.to_string() + "\n" + PEER_CONTENT + "\n";
+
+        let _cleanup = prepare_test_conf(TEST_CONF_FILE, &content);
+        let mut wg_conf = WgConf::open(TEST_CONF_FILE).unwrap();
+
+        // Act
+        let res = wg_conf.generate_peer(
+            "10.0.0.2".parse().unwrap(),
+            "wg.example.domain".parse().unwrap(),
+            vec!["0.0.0.0/0".parse().unwrap()],
+            Some("8.8.8.8".parse().unwrap()),
+            true,
+            Some(10),
+        );
+        let count = wg_conf.peers().unwrap().count();
+        let peers_iter = wg_conf.peers().unwrap();
+        let last_peer = peers_iter.last();
+
+        // Assert
+        assert!(res.is_ok());
+        assert_eq!(3, count);
+        assert!(last_peer.is_some());
+
+        let last_peer = last_peer.unwrap();
+        assert_eq!(
+            "10.0.0.2/32",
+            last_peer.allowed_ips.first().unwrap().to_string()
+        );
+        assert!(last_peer.endpoint.is_none());
+        assert!(last_peer.preshared_key.is_some());
+        assert_eq!(10, last_peer.persistent_keepalive.unwrap());
+
+        let client_conf = res.unwrap();
+
+        let client_interface = client_conf.interface();
+        let regenerated_client_pub_key =
+            WgKey::generate_public_key(&client_interface.private_key).unwrap();
+        assert_eq!(*&regenerated_client_pub_key, *last_peer.public_key());
+        assert_eq!("10.0.0.2/32", client_interface.address().to_string());
+        assert_eq!("8.8.8.8", client_interface.dns.unwrap().to_string());
+        assert!(client_interface.listen_port().is_none());
+        assert!(client_interface.post_up.is_none());
+        assert!(client_interface.post_down.is_none());
+
+        let client_peer_w_server = client_conf.peers().first().unwrap();
+        assert_eq!(wg_conf.pub_key().unwrap(), client_peer_w_server.public_key);
+        assert_eq!(
+            "0.0.0.0/0",
+            client_peer_w_server
+                .allowed_ips
+                .first()
+                .unwrap()
+                .to_string()
+        );
+        assert_eq!(
+            "wg.example.domain:8080",
+            client_peer_w_server.endpoint.clone().unwrap().to_string()
         );
         assert_eq!(
             last_peer.preshared_key(),

--- a/src/wg_peer.rs
+++ b/src/wg_peer.rs
@@ -35,7 +35,7 @@ impl ToString for SocketAddrExt {
     fn to_string(&self) -> String {
         match self {
             SocketAddrExt::Socket(socket_addr) => socket_addr.to_string(),
-            SocketAddrExt::Domain(domain_url) => domain_url.clone(),
+            SocketAddrExt::Domain(domain_name) => domain_name.clone(),
         }
     }
 }

--- a/src/wg_peer.rs
+++ b/src/wg_peer.rs
@@ -14,12 +14,38 @@ const ENDPOINT: &'static str = "Endpoint";
 const PRESHARED_KEY: &'static str = "PresharedKey";
 const PERSISTENT_KEEPALIVE: &'static str = "PersistentKeepalive";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketAddrExt {
+    Socket(SocketAddr),
+    Domain(String)    
+}
+
+impl std::str::FromStr for SocketAddrExt {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Ok(ip) = input.parse::<SocketAddr>() {
+            return Ok(Self::Socket(ip));
+        }
+        Ok(Self::Domain(input.to_string()))
+    }
+}
+
+impl ToString for SocketAddrExt {
+    fn to_string(&self) -> String {
+        match self {
+            SocketAddrExt::Socket(socket_addr) => socket_addr.to_string(),
+            SocketAddrExt::Domain(domain_url) => domain_url.clone(),
+        }
+    }
+}
+
 /// Represents WG \[Peer\] section
 #[derive(Clone, PartialEq, Eq)]
 pub struct WgPeer {
     pub(crate) public_key: WgKey,
     pub(crate) allowed_ips: Vec<IpNetwork>,
-    pub(crate) endpoint: Option<SocketAddr>,
+    pub(crate) endpoint: Option<SocketAddrExt>,
     pub(crate) preshared_key: Option<WgKey>,
     pub(crate) persistent_keepalive: Option<u16>,
 }
@@ -83,7 +109,7 @@ impl WgPeer {
     pub fn new(
         public_key: WgKey,
         allowed_ips: Vec<IpNetwork>,
-        endpoint: Option<SocketAddr>,
+        endpoint: Option<SocketAddrExt>,
         preshared_key: Option<WgKey>,
         persistent_keepalive: Option<u16>,
     ) -> WgPeer {
@@ -117,7 +143,7 @@ impl WgPeer {
             .collect();
         let allowed_ips = allowed_ips?;
 
-        let endpoint: Option<SocketAddr> = endpoint
+        let endpoint: Option<SocketAddrExt> = endpoint
             .map(|endpoint| {
                 endpoint.parse().map_err(|_| {
                     WgConfError::ValidationFailed("invalid endpoint raw value".to_string())
@@ -159,7 +185,7 @@ impl WgPeer {
     pub fn allowed_ips(&self) -> &[IpNetwork] {
         &self.allowed_ips
     }
-    pub fn endpoint(&self) -> Option<&SocketAddr> {
+    pub fn endpoint(&self) -> Option<&SocketAddrExt> {
         self.endpoint.as_ref()
     }
     pub fn preshared_key(&self) -> Option<&WgKey> {


### PR DESCRIPTION
Hi,

For servers that use a dynamic IP, this pr allows clients to use domain name instead of IP address.

### Changes

- Extended the standard `IpAddr` and `SocketAddr`.
- If you provide a domain name, it returns a string.

Thank you for sharing this crate. I recently wanted to embed `WireGuard` into my new project, a web app dashboard to manage the VPN.